### PR TITLE
require hyva-themes/module-magento2-admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
+        "hyva-themes/module-magento2-admin": "^1.1",
         "magento/framework": ">=103.0.0",
         "magento/module-config": ">=101.0.0",
         "magento/module-backend": ">=100.2.0"
@@ -25,6 +26,10 @@
         "magento": {
             "type": "composer",
             "url": "https://repo.magento.com/"
+        },
+        "hyva-admin": {
+            "type": "github",
+            "url": "https://github.com/hyva-themes/magento2-hyva-admin.git"
         }
     },
     "autoload": {


### PR DESCRIPTION
Since the 0.3.0 this module requires hyva-admin to work, but it is not required, so an exception is thrown on this dev dashboard.